### PR TITLE
Add JSON-LD to HTML and align with ELFIE

### DIFF
--- a/asgs_dataset/app.py
+++ b/asgs_dataset/app.py
@@ -4,10 +4,22 @@ from flask import Flask
 from asgs_dataset.controller import controller
 import pyldapi
 import argparse
+from jinja2 import Markup
 
 app = Flask(__name__, template_folder=conf.TEMPLATES_DIR, static_folder=conf.STATIC_DIR)
 app.register_blueprint(controller)
 
+@app.context_processor
+def utility_processor():
+    def include_raw(url):
+        import urllib.request
+        import json
+        res = urllib.request.urlopen(url)
+        res_body = res.read()
+        jo = json.loads(res_body.decode("utf-8"))
+        j = json.dumps(jo, indent=4)
+        return Markup(j)
+    return dict(include_raw=include_raw)
 
 def run():
     parser = argparse.ArgumentParser(description='ASGS Dataset LDAPI')

--- a/asgs_dataset/view/ldapi/__init__.py
+++ b/asgs_dataset/view/ldapi/__init__.py
@@ -164,6 +164,42 @@ class ASGSClassRenderer(pyldapi.Renderer):
                 raise RuntimeError("ASGS RDF Renderer doesn't know which graph to render")
         if self.format in {'application/ld+json', 'application/json'}:
             serial_format = 'json-ld'
+            fallback_context = {
+               "schema": "http://schema.org/",
+               "skos": "https://www.w3.org/TR/skos-reference/",
+               "gsp": "http://www.opengis.net/ont/geosparql#",
+               "description": "schema:description",
+               "geo": "schema:geo",
+               "hasGeometry": "gsp:hasGeometry",
+                "asWKT": "gsp:asWKT",
+               "image": {
+               "@id": "schema:image",
+               "@type": "@id"
+               },
+               "name": "schema:name",
+               "sameAs": "schema:sameAs",
+               "related": "skos:related"
+            }
+            context = [
+               "https://opengeospatial.github.io/ELFIE/json-ld/elf.jsonld",
+               "https://opengeospatial.github.io/ELFIE/json-ld/elf-network.jsonld",
+               {
+                  "dct": "http://purl.org/dc/terms/",
+                  "loci": "http://linked.data.gov.au/def/loci#",
+                  "geox": "http://linked.data.gov.au/def/geox#",
+                  "asgs-id": "http://linked.data.gov.au/def/asgs/id#",
+                  "asgs": "http://linked.data.gov.au/def/asgs#",
+                  "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+               }
+            ]
+            res = None
+            from urllib.error import HTTPError
+            try:
+               res = g.serialize(format='json-ld', context=context, auto_compact=True)
+            except HTTPError as he:
+               #use fallback context instead
+               res = g.serialize(format='json-ld', context=fallback_context, auto_compact=True)
+            return Response(res, mimetype=self.format, headers=self.headers)
         elif self.format in self.RDF_MIMETYPES:
             serial_format = self.format
         else:

--- a/asgs_dataset/view/templates/asgs-AUS-en.html
+++ b/asgs_dataset/view/templates/asgs-AUS-en.html
@@ -1,5 +1,11 @@
 {% extends "layout.html" %}
 
+    {% block extra_scripts %}
+       <script type="application/ld+json"> 
+          {{ include_raw(uri+"?_format=application/ld+json") }}
+       </script>
+    {% endblock %}
+
     {% block content %}
     <h1>ASGS Feature - {{ deets['name'] }}</h1>
     <h3><a href="{{ uri }}">{{ uri }}</a></h3>

--- a/asgs_dataset/view/templates/asgs-CED-en.html
+++ b/asgs_dataset/view/templates/asgs-CED-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-GCCSA-en.html
+++ b/asgs_dataset/view/templates/asgs-GCCSA-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-IARE-en.html
+++ b/asgs_dataset/view/templates/asgs-IARE-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-ILOC-en.html
+++ b/asgs_dataset/view/templates/asgs-ILOC-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-IREG-en.html
+++ b/asgs_dataset/view/templates/asgs-IREG-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-LGA-en.html
+++ b/asgs_dataset/view/templates/asgs-LGA-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-MB-en.html
+++ b/asgs_dataset/view/templates/asgs-MB-en.html
@@ -1,4 +1,14 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-NRMR-en.html
+++ b/asgs_dataset/view/templates/asgs-NRMR-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-RA-en.html
+++ b/asgs_dataset/view/templates/asgs-RA-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SA1-en.html
+++ b/asgs_dataset/view/templates/asgs-SA1-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SA2-en.html
+++ b/asgs_dataset/view/templates/asgs-SA2-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SA3-en.html
+++ b/asgs_dataset/view/templates/asgs-SA3-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SA4-en.html
+++ b/asgs_dataset/view/templates/asgs-SA4-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SOS-en.html
+++ b/asgs_dataset/view/templates/asgs-SOS-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SOSR-en.html
+++ b/asgs_dataset/view/templates/asgs-SOSR-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-SSC-en.html
+++ b/asgs_dataset/view/templates/asgs-SSC-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-STATE-en.html
+++ b/asgs_dataset/view/templates/asgs-STATE-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 
     {% block content %}
     <h1>ASGS State Feature - {{ deets['name'] }} ({{ deets['name_abbrev'] }})</h1>

--- a/asgs_dataset/view/templates/asgs-SUA-en.html
+++ b/asgs_dataset/view/templates/asgs-SUA-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/asgs-UCL-en.html
+++ b/asgs_dataset/view/templates/asgs-UCL-en.html
@@ -1,4 +1,9 @@
 {% extends "layout.html" %}
+{% block extra_scripts %}
+    <script type="application/ld+json"> 
+       {{ include_raw(request.url + "&_format=application/ld+json") }}
+    </script>
+{% endblock %}
 {% block extra_head_stylesheets %}
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.1/mapbox-gl.css' rel='stylesheet' />
 {% endblock %}

--- a/asgs_dataset/view/templates/layout.html
+++ b/asgs_dataset/view/templates/layout.html
@@ -5,6 +5,8 @@
     <title>ASGS LD API</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='simple.css') }}" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Muli">
+    {% block extra_scripts%}
+    {% endblock %}
     {% block extra_head_stylesheets%}
     {% endblock %}
     {% block extra_head_css%}


### PR DESCRIPTION
This PR addresses #21 

Modifies the json-ld `loci` view to add ELFIE contexts and other loci contexts to render a slightly more compact rendering aligning with (S)ELFIE recommendations.